### PR TITLE
Shrink size of fields in unique constraint for MyISAM compat

### DIFF
--- a/reversion/migrations/0001_squashed_0004_auto_20160611_1202.py
+++ b/reversion/migrations/0001_squashed_0004_auto_20160611_1202.py
@@ -35,13 +35,13 @@ class Migration(migrations.Migration):
             name='Version',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('object_id', models.CharField(help_text='Primary key of the model under version control.', max_length=191)),
+                ('object_id', models.CharField(help_text='Primary key of the model under version control.', max_length=100)),
                 ('format', models.CharField(help_text='The serialization format used by this model.', max_length=255)),
                 ('serialized_data', models.TextField(help_text='The serialized form of this version of the model.')),
                 ('object_repr', models.TextField(help_text='A string representation of the object.')),
                 ('content_type', models.ForeignKey(help_text='Content type of the model under version control.', on_delete=django.db.models.deletion.CASCADE, to='contenttypes.ContentType')),
                 ('revision', models.ForeignKey(help_text='The revision that contains this version.', on_delete=django.db.models.deletion.CASCADE, to='reversion.Revision')),
-                ('db', models.CharField(help_text='The database the model under version control is stored in.', max_length=191)),
+                ('db', models.CharField(help_text='The database the model under version control is stored in.', max_length=100)),
             ],
             options={
                 "ordering": ("-pk",)

--- a/reversion/migrations/0003_auto_20160601_1600.py
+++ b/reversion/migrations/0003_auto_20160601_1600.py
@@ -91,7 +91,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='version',
             name='object_id',
-            field=models.CharField(help_text='Primary key of the model under version control.', max_length=191),
+            field=models.CharField(help_text='Primary key of the model under version control.', max_length=100),
         ),
         migrations.AlterField(
             model_name='revision',
@@ -101,7 +101,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='version',
             name='db',
-            field=models.CharField(null=True, help_text='The database the model under version control is stored in.', max_length=191),
+            field=models.CharField(null=True, help_text='The database the model under version control is stored in.', max_length=100),
         ),
         migrations.RunPython(de_dupe_version_table),
         migrations.RunPython(set_version_db),

--- a/reversion/models.py
+++ b/reversion/models.py
@@ -191,7 +191,7 @@ class Version(models.Model):
     )
 
     object_id = models.CharField(
-        max_length=191,
+        max_length=100,
         help_text="Primary key of the model under version control.",
     )
 
@@ -216,7 +216,7 @@ class Version(models.Model):
     )
 
     db = models.CharField(
-        max_length=191,
+        max_length=100,
         help_text="The database the model under version control is stored in.",
     )
 


### PR DESCRIPTION
This is a workaround for
> Specified key was too long; max key length is 1000 bytes

See https://github.com/etianen/django-reversion/issues/604

Note, the number 100 was arrived at via:
```
191                # current column widths
 - (
      2 * 5        # bytes per int
    + 2 * 191 * 3  # bytes per varchar
    - 1000         # index limit on MyISAM
) / 2              # columns to shrink
= 113

So make that 100 to be safe.
```